### PR TITLE
[HMA-349][DC] Added raml documentation for the `/full-claimant-detail…

### DIFF
--- a/docs/fullClaimentDetails.md
+++ b/docs/fullClaimentDetails.md
@@ -14,11 +14,6 @@ Return Full Claimant Details object
 
 *  **URL Params**
 
-  `claims=yes`
-
-   Supplying the claims query parameter will drive the service to return all claims associated from the supplied NINO.
-
-
    **Required:**
  
    `nino=[Nino]`

--- a/resources/public/api/conf/1.0/application.raml
+++ b/resources/public/api/conf/1.0/application.raml
@@ -159,6 +159,24 @@ uses:
                     examples:
                       example-1:
                         value: !include examples/get-claiment-details-example-1.json
+        /full-claimant-details:
+          get:
+            displayName: Get full claiment details
+            description: This endpoint retrieves the full claiment details.
+            is: [headers.acceptHeader]
+            (annotations.scope): "read:native-apps-api-orchestration"
+            securedBy: [ sec.oauth_2_0: { scopes: [ "read:native-apps-api-orchestration" ] } ]
+            queryParameters:
+              journeyId:
+                type: string
+                required: false
+            responses:
+              200:
+                body:
+                  application/json:
+                    examples:
+                      example-1:
+                        value: !include examples/get-full-claiment-details-example-1.json
         /renewal:
           post:
             displayName: Submit renewal

--- a/resources/public/api/conf/1.0/examples/get-full-claiment-details-example-1.json
+++ b/resources/public/api/conf/1.0/examples/get-full-claiment-details-example-1.json
@@ -1,0 +1,26 @@
+{
+        "references": [
+                {
+                        "household": {
+                                "barcodeReference": "200000000000013",
+                                "applicationID": "198765432134567",
+                                "applicant1": {
+                                        "nino": "CS700100A",
+                                        "title": "MR",
+                                        "firstForename": "JOHN",
+                                        "secondForename": "",
+                                        "surname": "DENSMORE"
+                                },
+                                "householdEndReason": ""
+                        },
+                        "renewal": {
+                                "awardStartDate": "12/10/2030",
+                                "awardEndDate": "12/10/2010",
+                                "renewalStatus": "NOT_SUBMITTED",
+                                "renewalNoticeIssuedDate": "12/10/2030",
+                                "renewalNoticeFirstSpecifiedDate": "12/10/2010",
+                                "renewalFormType": "D"
+                        }
+                }
+        ]
+}


### PR DESCRIPTION
…s` endpoint to enable it to be called externally, i.e. directly from the mobile app.